### PR TITLE
fix(ocr): migrate to mistralai v2 SDK

### DIFF
--- a/app/utils/document_loader.py
+++ b/app/utils/document_loader.py
@@ -304,10 +304,15 @@ def _mistral_ocr_client():
     # Lazy import to avoid hard dependency at import time
     try:
         from mistralai import Mistral
-    except Exception as e:
-        raise RuntimeError(
-            "mistralai package is required for OCR. Please install 'mistralai' and set MISTRAL_API_KEY."
-        ) from e
+    except ImportError:
+        # mistralai >= 2.0 turned the top-level package into a namespace and
+        # moved the SDK into the ``mistralai.client`` subpackage.
+        try:
+            from mistralai.client import Mistral
+        except Exception as e:
+            raise RuntimeError(
+                "mistralai package is required for OCR. Please install 'mistralai' and set MISTRAL_API_KEY."
+            ) from e
 
     if not MISTRAL_API_KEY:
         raise RuntimeError(

--- a/app/utils/document_loader.py
+++ b/app/utils/document_loader.py
@@ -303,16 +303,11 @@ def _mistral_ocr_client():
     """
     # Lazy import to avoid hard dependency at import time
     try:
-        from mistralai import Mistral
-    except ImportError:
-        # mistralai >= 2.0 turned the top-level package into a namespace and
-        # moved the SDK into the ``mistralai.client`` subpackage.
-        try:
-            from mistralai.client import Mistral
-        except Exception as e:
-            raise RuntimeError(
-                "mistralai package is required for OCR. Please install 'mistralai' and set MISTRAL_API_KEY."
-            ) from e
+        from mistralai.client import Mistral
+    except Exception as e:
+        raise RuntimeError(
+            "mistralai package is required for OCR. Please install 'mistralai>=2.0.0' and set MISTRAL_API_KEY."
+        ) from e
 
     if not MISTRAL_API_KEY:
         raise RuntimeError(

--- a/requirements.lite.txt
+++ b/requirements.lite.txt
@@ -18,22 +18,22 @@ openpyxl==3.1.5
 docx2txt==0.9
 python-docx==1.1.2  # .docx header/footer extraction (pandoc drops them)
 pypandoc==1.15
-python-oxmsg>=0.0.2,<0.1  # .msg (Outlook) extraction; also a transitive of unstructured
-Pillow>=10.0.0  # normalize standalone images (incl. multi-page TIFF) for OCR
+python-oxmsg==0.0.2  # .msg (Outlook) extraction; also a transitive of unstructured
+Pillow==12.3.0  # normalize standalone images (incl. multi-page TIFF) for OCR
 PyJWT==2.13.0
 asyncpg==0.29.0
 python-multipart==0.0.32
 aiofiles==24.1.0
-pymongo>=4.12.0,<5
+pymongo==4.17.0
 langchain-mongodb==0.11.0
 cryptography==46.0.7
 python-magic==0.4.27
 python-pptx==1.0.2
 xlrd==2.0.2
 langchain-aws==1.6.0
-boto3>=1.42.42,<2
+boto3==1.43.48
 chardet==5.2.0
 langchain-ollama==1.1.0
-tenacity>=9.0.0
-msoffcrypto-tool>=6.0.0,<7
-mistralai>=2.0.0
+tenacity==9.1.4
+msoffcrypto-tool==6.0.0
+mistralai==2.6.0

--- a/requirements.lite.txt
+++ b/requirements.lite.txt
@@ -36,4 +36,4 @@ chardet==5.2.0
 langchain-ollama==1.1.0
 tenacity>=9.0.0
 msoffcrypto-tool>=6.0.0,<7
-mistralai>=1.0.2
+mistralai>=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,4 +42,4 @@ pydantic>=2.10.6,<3
 chardet==5.2.0
 tenacity>=9.0.0
 msoffcrypto-tool>=6.0.0,<7
-mistralai>=1.0.2
+mistralai>=2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ langchain-openai==1.3.2
 langchain-core==1.4.8
 langchain-aws==1.6.0
 langchain-text-splitters==1.1.2
-boto3>=1.42.42,<2
+boto3==1.43.48
 sqlalchemy==2.0.41
 python-dotenv==1.2.2
 fastapi==0.115.12
@@ -20,8 +20,8 @@ openpyxl==3.1.5
 docx2txt==0.9
 python-docx==1.1.2  # .docx header/footer extraction (pandoc drops them)
 pypandoc==1.15
-python-oxmsg>=0.0.2,<0.1  # .msg (Outlook) extraction; also a transitive of unstructured
-Pillow>=10.0.0  # normalize standalone images (incl. multi-page TIFF) for OCR
+python-oxmsg==0.0.2  # .msg (Outlook) extraction; also a transitive of unstructured
+Pillow==12.3.0  # normalize standalone images (incl. multi-page TIFF) for OCR
 PyJWT==2.13.0
 asyncpg==0.29.0
 python-multipart==0.0.32
@@ -29,7 +29,7 @@ sentence_transformers==3.1.1
 aiofiles==24.1.0
 rapidocr-onnxruntime==1.4.4
 opencv-python-headless==4.9.0.80
-pymongo>=4.12.0,<5
+pymongo==4.17.0
 langchain-mongodb==0.11.0
 langchain-ollama==1.1.0
 langchain-huggingface==1.2.2
@@ -38,8 +38,8 @@ cryptography==46.0.7
 python-magic==0.4.27
 python-pptx==1.0.2
 xlrd==2.0.2
-pydantic>=2.10.6,<3
+pydantic==2.13.4
 chardet==5.2.0
-tenacity>=9.0.0
-msoffcrypto-tool>=6.0.0,<7
-mistralai>=2.0.0
+tenacity==9.1.4
+msoffcrypto-tool==6.0.0
+mistralai==2.6.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,5 +1,5 @@
 pytest==9.0.3
 pytest-asyncio==1.3.0
-testcontainers[postgres]>=4.14.0
+testcontainers[postgres]==4.14.2
 mongomock==4.3.0
-httpx>=0.28,<1
+httpx==0.28.1

--- a/tests/utils/test_document_loader.py
+++ b/tests/utils/test_document_loader.py
@@ -96,7 +96,7 @@ def test_safe_pdf_loader_lazy_load():
 
 
 def _make_mistral_module(pages=None, raise_exc=None):
-    """Build a fake ``mistralai`` module whose ``Mistral().ocr.process`` is stubbed.
+    """Build a fake ``mistralai.client`` module whose ``Mistral().ocr.process`` is stubbed.
 
     Returns ``(fake_module, client)`` so callers can both inject the module via
     ``sys.modules`` and make assertions on the OCR client.
@@ -124,7 +124,9 @@ def test_safe_pdf_loader_ocr_maps_pages():
     fake_module, client = _make_mistral_module(pages=[page0, page1])
 
     loader = SafePyPDFLoader("dummy.pdf")
-    with patch.dict("sys.modules", {"mistralai": fake_module}), patch.object(
+    with patch.dict(
+        "sys.modules", {"mistralai": fake_module, "mistralai.client": fake_module}
+    ), patch.object(
         document_loader, "MISTRAL_API_KEY", "test-key"
     ), patch.object(SafePyPDFLoader, "_encode_pdf_b64", return_value="b64data"):
         result = loader.load()
@@ -155,7 +157,9 @@ def test_safe_pdf_loader_empty_pages_returns_placeholder():
     fake_module, _ = _make_mistral_module(pages=[])
 
     loader = SafePyPDFLoader("dummy.pdf")
-    with patch.dict("sys.modules", {"mistralai": fake_module}), patch.object(
+    with patch.dict(
+        "sys.modules", {"mistralai": fake_module, "mistralai.client": fake_module}
+    ), patch.object(
         document_loader, "MISTRAL_API_KEY", "test-key"
     ), patch.object(SafePyPDFLoader, "_encode_pdf_b64", return_value="b64data"):
         result = loader.load()
@@ -173,7 +177,9 @@ def test_safe_pdf_loader_ocr_error_propagates():
     fake_module, _ = _make_mistral_module(raise_exc=RuntimeError("OCR boom"))
 
     loader = SafePyPDFLoader("dummy.pdf")
-    with patch.dict("sys.modules", {"mistralai": fake_module}), patch.object(
+    with patch.dict(
+        "sys.modules", {"mistralai": fake_module, "mistralai.client": fake_module}
+    ), patch.object(
         document_loader, "MISTRAL_API_KEY", "test-key"
     ), patch.object(SafePyPDFLoader, "_encode_pdf_b64", return_value="b64data"):
         with pytest.raises(RuntimeError, match="OCR boom"):
@@ -188,7 +194,9 @@ def test_safe_pdf_loader_requires_api_key():
     fake_module, _ = _make_mistral_module(pages=[])
 
     loader = SafePyPDFLoader("dummy.pdf")
-    with patch.dict("sys.modules", {"mistralai": fake_module}), patch.object(
+    with patch.dict(
+        "sys.modules", {"mistralai": fake_module, "mistralai.client": fake_module}
+    ), patch.object(
         document_loader, "MISTRAL_API_KEY", ""
     ):
         with pytest.raises(RuntimeError, match="MISTRAL_API_KEY"):
@@ -766,7 +774,9 @@ def test_image_ocr_loader_single_image(tmp_path):
     )
 
     loader = ImageOCRLoader(str(p))
-    with patch.dict("sys.modules", {"mistralai": fake_module}), patch.object(
+    with patch.dict(
+        "sys.modules", {"mistralai": fake_module, "mistralai.client": fake_module}
+    ), patch.object(
         document_loader, "MISTRAL_API_KEY", "test-key"
     ):
         docs = loader.load()
@@ -792,7 +802,9 @@ def test_image_ocr_loader_multipage_tiff_yields_one_doc_per_frame(tmp_path):
     )
 
     loader = ImageOCRLoader(str(p))
-    with patch.dict("sys.modules", {"mistralai": fake_module}), patch.object(
+    with patch.dict(
+        "sys.modules", {"mistralai": fake_module, "mistralai.client": fake_module}
+    ), patch.object(
         document_loader, "MISTRAL_API_KEY", "test-key"
     ):
         docs = loader.load()
@@ -816,7 +828,9 @@ def test_image_ocr_loader_caps_frames(tmp_path):
     )
 
     loader = ImageOCRLoader(str(p))
-    with patch.dict("sys.modules", {"mistralai": fake_module}), patch.object(
+    with patch.dict(
+        "sys.modules", {"mistralai": fake_module, "mistralai.client": fake_module}
+    ), patch.object(
         document_loader, "MISTRAL_API_KEY", "test-key"
     ), patch.object(document_loader, "IMAGE_OCR_MAX_PAGES", 2):
         docs = loader.load()
@@ -838,7 +852,9 @@ def test_image_ocr_loader_normalizes_cmyk_jpeg(tmp_path):
         pages=[MagicMock(index=0, markdown="text")]
     )
     loader = ImageOCRLoader(str(p))
-    with patch.dict("sys.modules", {"mistralai": fake_module}), patch.object(
+    with patch.dict(
+        "sys.modules", {"mistralai": fake_module, "mistralai.client": fake_module}
+    ), patch.object(
         document_loader, "MISTRAL_API_KEY", "test-key"
     ):
         loader.load()
@@ -860,7 +876,9 @@ def test_image_ocr_loader_zero_cap_means_unlimited(tmp_path):
         pages=[MagicMock(index=0, markdown="scanned text")]
     )
     loader = ImageOCRLoader(str(p))
-    with patch.dict("sys.modules", {"mistralai": fake_module}), patch.object(
+    with patch.dict(
+        "sys.modules", {"mistralai": fake_module, "mistralai.client": fake_module}
+    ), patch.object(
         document_loader, "MISTRAL_API_KEY", "test-key"
     ), patch.object(document_loader, "IMAGE_OCR_MAX_PAGES", 0):
         docs = loader.load()
@@ -878,7 +896,9 @@ def test_image_ocr_loader_requires_api_key(tmp_path):
 
     fake_module, _ = _make_mistral_module(pages=[])
     loader = ImageOCRLoader(str(p))
-    with patch.dict("sys.modules", {"mistralai": fake_module}), patch.object(
+    with patch.dict(
+        "sys.modules", {"mistralai": fake_module, "mistralai.client": fake_module}
+    ), patch.object(
         document_loader, "MISTRAL_API_KEY", ""
     ):
         with pytest.raises(RuntimeError, match="MISTRAL_API_KEY"):

--- a/tests/utils/test_lazy_load.py
+++ b/tests/utils/test_lazy_load.py
@@ -41,7 +41,9 @@ def _mock_mistral_ocr(num_pages=1):
     ]
     client.ocr.process.return_value = response
     fake_module.Mistral.return_value = client
-    with patch.dict("sys.modules", {"mistralai": fake_module}), patch.object(
+    with patch.dict(
+        "sys.modules", {"mistralai": fake_module, "mistralai.client": fake_module}
+    ), patch.object(
         document_loader, "MISTRAL_API_KEY", "test-key"
     ), patch.object(
         document_loader.SafePyPDFLoader, "_encode_pdf_b64", return_value="b64"


### PR DESCRIPTION
## Problem

Containers built recently fail all OCR requests (`/embed` returns 400) with:

```
ImportError: cannot import name 'Mistral' from 'mistralai' (unknown location)
RuntimeError: mistralai package is required for OCR. Please install 'mistralai' and set MISTRAL_API_KEY.
```

The requirements pinned `mistralai>=1.0.2`, so fresh image builds silently picked up the new mistralai v2 SDK (currently 2.6.0). In v2 the top-level `mistralai` package became an empty namespace package and the SDK moved to the `mistralai.client` subpackage, breaking `from mistralai import Mistral`.

## Changes

### Migrate to mistralai v2

- **`app/utils/document_loader.py`** — `_mistral_ocr_client()` imports `Mistral` from `mistralai.client` (v2 layout); error message now points to `mistralai>=2.0.0`.
- **`tests/utils/test_document_loader.py` / `tests/utils/test_lazy_load.py`** — OCR mocks inject the fake module under both `mistralai` and `mistralai.client` in `sys.modules`, matching the new import path.

No other code changes were needed: verified against a real mistralai 2.6.0 install that the client builds, `ocr.process` keeps the same signature, and both payload shapes the loader sends (base64 `document_url` for PDFs, `image_url` for images) validate against the v2 request models.

### Pin all requirements to exact versions

To prevent this class of breakage from recurring, every ranged specifier in `requirements.txt`, `requirements.lite.txt`, and `test_requirements.txt` is replaced with the exact version pip resolves today on Python 3.12 (the version used by both Docker images and CI) — e.g. `boto3==1.43.48`, `Pillow==12.3.0`, `pymongo==4.17.0`, `pydantic==2.13.4`, `tenacity==9.1.4`, `mistralai==2.6.0`, `testcontainers[postgres]==4.14.2`, `httpx==0.28.1`. Dependency upgrades now only happen deliberately. Each pinned set was verified to resolve without conflicts.

## Testing

- Full unit test suite against the pinned dependency set: 230 passed, 7 skipped (integration tests excluded; they require Docker/testcontainers).
- Manual verification of import, client construction, and OCR request-model validation against mistralai 2.6.0.
- `pip install --dry-run` confirms both pinned requirement sets (lite, and main + test) resolve cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W1UqzsQzEeE2SKnHMEz4rz